### PR TITLE
Some more improvements

### DIFF
--- a/include/async_web_server_cpp/http_reply.hpp
+++ b/include/async_web_server_cpp/http_reply.hpp
@@ -112,7 +112,7 @@ public:
                            const std::vector<HttpHeader> &headers,
                            const std::string &content);
 
-  void operator()(const HttpRequest &, boost::shared_ptr<HttpConnection>, const char* begin, const char* end);
+  bool operator()(const HttpRequest &, boost::shared_ptr<HttpConnection>, const char* begin, const char* end);
 
 private:
   ReplyBuilder reply_builder_;
@@ -129,7 +129,7 @@ public:
 			 const std::string& filename,
 			 const std::vector<HttpHeader>& headers);
 
-  void operator()(const HttpRequest &, boost::shared_ptr<HttpConnection>, const char* begin, const char* end);
+  bool operator()(const HttpRequest &, boost::shared_ptr<HttpConnection>, const char* begin, const char* end);
 
 private:
   HttpReply::status_type status_;

--- a/include/async_web_server_cpp/http_reply.hpp
+++ b/include/async_web_server_cpp/http_reply.hpp
@@ -7,6 +7,7 @@
 #include "async_web_server_cpp/http_header.hpp"
 #include "async_web_server_cpp/http_connection.hpp"
 #include "async_web_server_cpp/http_request_handler.hpp"
+#include <boost/filesystem.hpp>
 
 namespace async_web_server_cpp
 {
@@ -52,6 +53,18 @@ struct HttpReply
   static HttpServerRequestHandler from_file(HttpReply::status_type status,
       const std::string& content_type,
       const std::string& filename,
+      const std::vector<HttpHeader>& additional_headers = std::vector<HttpHeader>());
+
+  /**
+   * Create a request handler that reads files from the filesystem
+   * No content type is served and it is left to the browser to determine the content type
+   * @param path_root the prefix in the request path that should be ignored
+   * @param filesystem_root the path to search for the requested file
+   */
+  static HttpServerRequestHandler from_filesystem(HttpReply::status_type status,
+      const std::string& path_root,
+      const std::string& filesystem_root,
+      bool list_directories,
       const std::vector<HttpHeader>& additional_headers = std::vector<HttpHeader>());
 
   /**
@@ -135,6 +148,28 @@ private:
   HttpReply::status_type status_;
   std::vector<HttpHeader> headers_;
   std::string filename_;
+};
+
+/**
+ *  Request Handler that serves a responses from the filesystem from a base path
+ */
+class FilesystemHttpRequestHandler
+{
+public:
+  FilesystemHttpRequestHandler(HttpReply::status_type status,
+			       const std::string& path_root,
+			       const std::string& filesystem_root,
+			       bool list_directories,
+			       const std::vector<HttpHeader>& headers);
+
+  bool operator()(const HttpRequest &, boost::shared_ptr<HttpConnection>, const char* begin, const char* end);
+
+private:
+  HttpReply::status_type status_;
+  std::vector<HttpHeader> headers_;
+  std::string path_root_;
+  boost::filesystem::path filesystem_root_;
+  bool list_directories_;
 };
 
 }

--- a/include/async_web_server_cpp/http_reply.hpp
+++ b/include/async_web_server_cpp/http_reply.hpp
@@ -48,7 +48,6 @@ struct HttpReply
 
   /**
    * Create a request handler that sends the contents of a file
-   * NOTE: the file is only loaded once when the request handler is created
    */
   static HttpServerRequestHandler from_file(HttpReply::status_type status,
       const std::string& content_type,
@@ -118,6 +117,24 @@ public:
 private:
   ReplyBuilder reply_builder_;
   const std::string content_string_;
+};
+
+/**
+ *  Request Handler that serves a response from a file
+ */
+class FileHttpRequestHandler
+{
+public:
+  FileHttpRequestHandler(HttpReply::status_type status,
+			 const std::string& filename,
+			 const std::vector<HttpHeader>& headers);
+
+  void operator()(const HttpRequest &, boost::shared_ptr<HttpConnection>, const char* begin, const char* end);
+
+private:
+  HttpReply::status_type status_;
+  std::vector<HttpHeader> headers_;
+  std::string filename_;
 };
 
 }

--- a/include/async_web_server_cpp/http_request_handler.hpp
+++ b/include/async_web_server_cpp/http_request_handler.hpp
@@ -10,7 +10,13 @@ namespace async_web_server_cpp
 
 class HttpConnection;
 
-typedef boost::function<void(const HttpRequest &, boost::shared_ptr<HttpConnection>, const char* begin, const char* end)> HttpServerRequestHandler;
+/**
+ * A handler for requests
+ * Should return true if the request was successfuly handled
+ * Returning false will cause the next matching handler to be triggered
+ * If false is returned then nothing should be written to the connection
+ */
+typedef boost::function<bool(const HttpRequest &, boost::shared_ptr<HttpConnection>, const char* begin, const char* end)> HttpServerRequestHandler;
 
 /**
  * A hander that can dispatch to a request to different handlers depending on a
@@ -28,7 +34,7 @@ public:
 
   void addHandler(HandlerPredicate predicate, HttpServerRequestHandler handler);
 
-  void operator()(const HttpRequest &request, boost::shared_ptr<HttpConnection> connection, const char* begin, const char* end);
+  bool operator()(const HttpRequest &request, boost::shared_ptr<HttpConnection> connection, const char* begin, const char* end);
 
 private:
   HttpServerRequestHandler default_handler_;

--- a/include/async_web_server_cpp/websocket_request_handler.hpp
+++ b/include/async_web_server_cpp/websocket_request_handler.hpp
@@ -20,7 +20,7 @@ class WebsocketHttpRequestHandler
 {
 public:
   WebsocketHttpRequestHandler(WebsocketRequestHandler handler);
-  void operator()(const HttpRequest &request, boost::shared_ptr<HttpConnection> connection, const char* begin, const char* end);
+  bool operator()(const HttpRequest &request, boost::shared_ptr<HttpConnection> connection, const char* begin, const char* end);
 
   static const std::string KEY_MAGIC_STRING;
 private:

--- a/src/http_reply.cpp
+++ b/src/http_reply.cpp
@@ -264,7 +264,7 @@ FileHttpRequestHandler::FileHttpRequestHandler(HttpReply::status_type status,
 {
 }
 
-void FileHttpRequestHandler::operator()(const HttpRequest &request, boost::shared_ptr<HttpConnection> connection, const char* begin, const char* end)
+bool FileHttpRequestHandler::operator()(const HttpRequest &request, boost::shared_ptr<HttpConnection> connection, const char* begin, const char* end)
 {
   std::ifstream file_stream(filename_.c_str());
   std::stringstream file_buffer;
@@ -276,6 +276,7 @@ void FileHttpRequestHandler::operator()(const HttpRequest &request, boost::share
   reply_builder_.header("Content-Length", boost::lexical_cast<std::string>(content.size()));
   reply_builder_.write(connection);
   connection->write(content);
+  return true;
 }
 
 
@@ -305,10 +306,11 @@ StaticHttpRequestHandler::StaticHttpRequestHandler(HttpReply::status_type status
   reply_builder_.headers(headers);
 }
 
-void StaticHttpRequestHandler::operator()(const HttpRequest &request, boost::shared_ptr<HttpConnection> connection, const char* begin, const char* end)
+bool StaticHttpRequestHandler::operator()(const HttpRequest &request, boost::shared_ptr<HttpConnection> connection, const char* begin, const char* end)
 {
   reply_builder_.write(connection);
   connection->write(content_string_);
+  return true;
 }
 
 

--- a/src/http_request_handler.cpp
+++ b/src/http_request_handler.cpp
@@ -37,18 +37,18 @@ void HttpRequestHandlerGroup::addHandler(HandlerPredicate predicate, HttpServerR
 }
 
 
-void HttpRequestHandlerGroup::operator()(const HttpRequest &request, boost::shared_ptr<HttpConnection> connection, const char* begin, const char* end)
+bool HttpRequestHandlerGroup::operator()(const HttpRequest &request, boost::shared_ptr<HttpConnection> connection, const char* begin, const char* end)
 {
   for (int i = 0; i < handlers_.size(); ++i)
   {
     std::pair<HandlerPredicate, HttpServerRequestHandler> &handler = handlers_[i];
     if (handler.first(request))
     {
-      handler.second(request, connection, begin, end);
-      return;
+      if(handler.second(request, connection, begin, end))
+	return true;
     }
   }
-  default_handler_(request, connection, begin, end);
+  return default_handler_(request, connection, begin, end);
 }
 
 }

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -49,12 +49,15 @@ void HttpServer::handle_accept(const boost::system::error_code &e)
 
 void HttpServer::stop()
 {
-  acceptor_.cancel();
-  acceptor_.close();
+  if(acceptor_.is_open()) {
+    acceptor_.cancel();
+    acceptor_.close();
+  }
   io_service_.stop();
   // Wait for all threads in the pool to exit.
   for (std::size_t i = 0; i < threads_.size(); ++i)
     threads_[i]->join();
+  threads_.clear();
 }
 
 }

--- a/src/websocket_request_handler.cpp
+++ b/src/websocket_request_handler.cpp
@@ -17,7 +17,7 @@ WebsocketHttpRequestHandler::WebsocketHttpRequestHandler(WebsocketRequestHandler
   : handler_(handler) {}
 
 
-void WebsocketHttpRequestHandler::operator()(const HttpRequest &request, boost::shared_ptr<HttpConnection> connection, const char* begin, const char* end)
+bool WebsocketHttpRequestHandler::operator()(const HttpRequest &request, boost::shared_ptr<HttpConnection> connection, const char* begin, const char* end)
 {
   std::string connection_header = request.get_header_value_or_default("Connection", "");
   std::string upgrade_header = request.get_header_value_or_default("Upgrade", "");
@@ -60,6 +60,7 @@ void WebsocketHttpRequestHandler::operator()(const HttpRequest &request, boost::
   {
     async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::bad_request)(request, connection, begin, end);
   }
+  return true;
 }
 
 }


### PR DESCRIPTION
In addition to fixing a bug in calling stop and adding support for serving files relative to a given root this makes the following changes:
When serving files using HttpReply::from_file the files is now loaded every time a request is made because this appears to be common to most web servers (and makes development easier)
A small change was made to the API used to handle requests. This was done so that the request handler can reject a request after it has been passed to it by a handler group. This allows for much more complex filtering of requests. Although this is technically a breaking change, I am not aware of anyone else using this package at the moment and it only affects custom request handlers and makes no changes to use of existing handlers defined in async_web_server_cpp.