### PR TITLE
Fix compatibility issue with Apache2 websocket proxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq -y dpkg python-rosdep python-catkin-tools
   - sudo rosdep init
-  - rosdep update
+  - rosdep update --include-eol-distros
   - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update -qq
-  - sudo apt-get install -qq -y python-rosdep python-catkin-tools
+  - sudo apt-get install -qq -y dpkg python-rosdep python-catkin-tools
   - sudo rosdep init
   - rosdep update
   - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO

--- a/src/websocket_request_handler.cpp
+++ b/src/websocket_request_handler.cpp
@@ -1,4 +1,5 @@
 #include <boost/regex.hpp>
+#include <boost/algorithm/string.hpp>
 #include <openssl/sha.h>
 #include <openssl/hmac.h>
 #include <openssl/evp.h>
@@ -23,7 +24,8 @@ bool WebsocketHttpRequestHandler::operator()(const HttpRequest &request, boost::
   std::string upgrade_header = request.get_header_value_or_default("Upgrade", "");
   std::string websocket_key = request.get_header_value_or_default("Sec-WebSocket-Key", "");
 
-  if (connection_header.find("Upgrade") != std::string::npos && upgrade_header.compare("websocket") == 0
+  if (connection_header.find("Upgrade") != std::string::npos
+      && boost::iequals(upgrade_header, "websocket")
       && websocket_key.size() > 0)
   {
     std::string concat_key = websocket_key + KEY_MAGIC_STRING;


### PR DESCRIPTION
The Apache2 proxy uses "Upgrade: WebSocket" headers when forwarding a
WebSocket connection (note the camel case), breaking interoperability
with the web server.

The WebSocket RFC 6455 is somewhat inconclusive as it uses "Upgrade:
websocket" in all its examples and requires the "websocket" keyword in
section 4.1, but states that "WebSocket" has been registered as HTTP
Upgrade Token in section 11.2.

In any case, following the robustness principle to be as liberal as
possible when accepting data and as conservative as possible when
sending it, this pull request makes the "websocket" keyword matching case
insensitive in the request handler.