### PR TITLE
Fix unit tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_executable(test_web_server EXCLUDE_FROM_ALL test_web_server.cpp)
 target_link_libraries(test_web_server ${PROJECT_NAME} ${catkin_LIBRARIES})
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
 
 if(TARGET tests)
   add_dependencies(tests


### PR DESCRIPTION
Without this include specification, the tests can't find `ros/package.h`